### PR TITLE
fix(business/button): change font opacity for disabled buttons

### DIFF
--- a/projects/sbb-esta/angular-business/src/lib/button/button/button.component.scss
+++ b/projects/sbb-esta/angular-business/src/lib/button/button/button.component.scss
@@ -29,4 +29,22 @@
   &:disabled {
     opacity: 0.4;
   }
+
+  &-primary.sbb-button-has-icon:disabled,
+  &-primary:not(.sbb-button-has-icon):disabled,
+  &-alternative.sbb-button-has-icon:disabled,
+  &-alternative:not(.sbb-button-has-icon):disabled {
+    color: rgba($buttonDefaultColor, 0.5);
+  }
+
+  &-secondary.sbb-button-has-icon:disabled,
+  &-secondary:not(.sbb-button-has-icon):disabled,
+  &-icon:disabled {
+    color: rgba($buttonSecondaryColor, 0.5);
+  }
+
+  &-ghost.sbb-button-has-icon,
+  &-ghost:not(.sbb-button-has-icon) {
+    color: rgba($buttonSecondaryColor, 0.4);
+  }
 }

--- a/projects/sbb-esta/angular-public/src/lib/button/styles/_button-variables.scss
+++ b/projects/sbb-esta/angular-public/src/lib/button/styles/_button-variables.scss
@@ -23,3 +23,8 @@ $buttonGhostBorderColorHover: $sbbColorIron;
 $buttonFramelessColor: $sbbColorIron;
 $buttonFramelessColorHover: $sbbColorRed125;
 $buttonDisabledBorderColor: $sbbColorGreyMedium;
+
+@if $sbbBusiness {
+  $buttonGhostColor: $sbbColorGranite;
+  $buttonGhostBorderColor: $sbbColorGranite;
+}


### PR DESCRIPTION
This PR adds an opacity to the fonts on disabled buttons for all button types and changes the text color and text color on hover for the ghost button type.