### PR TITLE
fix(business/option): change color of active/hover to red125

### DIFF
--- a/projects/sbb-esta/angular-public/src/lib/option/styles/_option-variables.scss
+++ b/projects/sbb-esta/angular-public/src/lib/option/styles/_option-variables.scss
@@ -19,7 +19,8 @@ $optionSelectedBarTop: 3;
 $optionSelectedBarTopFirst: 6;
 
 @if $sbbBusiness {
-  $autocompleteOptionActiveColor: $sbbColorBlack;
+  $autocompleteOptionHoverColor: $sbbColorRed125;
+  $autocompleteOptionActiveColor: $sbbColorRed125;
   $dropdownPaddingBottom: 8px;
   $autocompletePaddingTop: 8px;
   $autocompletePaddingX: 8px;


### PR DESCRIPTION
This changes the color of the active option to red, as opposed to as discussed in #41. They adapted the style guide to this, because when using keyboard navigation to select an item the item should be red instead of black.

This affects the select and autocomplete component.