### PR TITLE
feat(business/accordion): expose accordion for business

### DIFF
--- a/projects/sbb-esta/angular-business/src/lib/accordion/accordion.ts
+++ b/projects/sbb-esta/angular-business/src/lib/accordion/accordion.ts
@@ -1,0 +1,1 @@
+export * from '../../../../angular-public/src/lib/accordion/accordion';

--- a/projects/sbb-esta/angular-business/src/public-api.ts
+++ b/projects/sbb-esta/angular-business/src/public-api.ts
@@ -1,6 +1,7 @@
 /*
  * Public API Surface of angular-business
  */
+export * from './lib/accordion/accordion';
 export * from './lib/autocomplete/autocomplete';
 export * from './lib/button/button';
 export * from './lib/checkbox/checkbox';

--- a/projects/sbb-esta/angular-public/src/lib/accordion/accordion/accordion.component.spec.ts
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/accordion/accordion.component.spec.ts
@@ -162,14 +162,14 @@ describe('AccordionComponent', () => {
 
     fixture.detectChanges();
 
-    expect(panel.nativeElement.querySelector('.sbb-expansion-indicator')).toBeTruthy(
+    expect(panel.nativeElement.querySelector('.sbb-no-toggle')).toBeFalsy(
       'Expected the expansion indicator to be present.'
     );
 
     fixture.componentInstance.hideToggle = true;
     fixture.detectChanges();
 
-    expect(panel.nativeElement.querySelector('.sbb-expansion-indicator')).toBeFalsy(
+    expect(panel.nativeElement.querySelector('.sbb-no-toggle')).toBeTruthy(
       'Expected the expansion indicator to be removed.'
     );
   });

--- a/projects/sbb-esta/angular-public/src/lib/accordion/expansion-panel-header/expansion-panel-header.component.html
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/expansion-panel-header/expansion-panel-header.component.html
@@ -1,4 +1,3 @@
 <span class="sbb-expansion-panel-header-content">
   <ng-content></ng-content>
 </span>
-<span class="sbb-expansion-indicator" *ngIf="showToggle()"></span>

--- a/projects/sbb-esta/angular-public/src/lib/accordion/expansion-panel-header/expansion-panel-header.component.html
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/expansion-panel-header/expansion-panel-header.component.html
@@ -1,7 +1,4 @@
 <span class="sbb-expansion-panel-header-content">
   <ng-content></ng-content>
 </span>
-<span class="sbb-expansion-indicator" *ngIf="showToggle()">
-  <sbb-icon-plus *ngIf="!panel.expanded"></sbb-icon-plus>
-  <sbb-icon-minus *ngIf="panel.expanded"></sbb-icon-minus>
-</span>
+<span class="sbb-expansion-indicator" *ngIf="showToggle()"></span>

--- a/projects/sbb-esta/angular-public/src/lib/accordion/expansion-panel-header/expansion-panel-header.component.scss
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/expansion-panel-header/expansion-panel-header.component.scss
@@ -4,14 +4,10 @@
   @include expansionPanelHeader();
 
   &.sbb-expanded {
-    & > .sbb-expansion-indicator {
-      @include expansionIndicator(true);
-    }
+    @include expansionIndicator(true);
   }
 
   &:not(.sbb-expanded) {
-    & > .sbb-expansion-indicator {
-      @include expansionIndicator(false);
-    }
+    @include expansionIndicator(false);
   }
 }

--- a/projects/sbb-esta/angular-public/src/lib/accordion/expansion-panel-header/expansion-panel-header.component.scss
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/expansion-panel-header/expansion-panel-header.component.scss
@@ -3,11 +3,13 @@
 .sbb-expansion-panel-header {
   @include expansionPanelHeader();
 
-  &.sbb-expanded {
-    @include expansionIndicator(true);
-  }
+  &:not(.sbb-no-toggle) {
+    &.sbb-expanded {
+      @include expansionIndicator(true);
+    }
 
-  &:not(.sbb-expanded) {
-    @include expansionIndicator(false);
+    &:not(.sbb-expanded) {
+      @include expansionIndicator(false);
+    }
   }
 }

--- a/projects/sbb-esta/angular-public/src/lib/accordion/expansion-panel-header/expansion-panel-header.component.scss
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/expansion-panel-header/expansion-panel-header.component.scss
@@ -5,5 +5,9 @@
 }
 
 .sbb-expansion-indicator {
-  @include expansionIndicator();
+  @if $sbbBusiness {
+    @include expansionIndicatorBusiness();
+  } @else {
+    @include expansionIndicator();
+  }
 }

--- a/projects/sbb-esta/angular-public/src/lib/accordion/expansion-panel-header/expansion-panel-header.component.scss
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/expansion-panel-header/expansion-panel-header.component.scss
@@ -2,12 +2,16 @@
 
 .sbb-expansion-panel-header {
   @include expansionPanelHeader();
-}
 
-.sbb-expansion-indicator {
-  @if $sbbBusiness {
-    @include expansionIndicatorBusiness();
-  } @else {
-    @include expansionIndicator();
+  &.sbb-expanded {
+    & > .sbb-expansion-indicator {
+      @include expansionIndicator(true);
+    }
+  }
+
+  &:not(.sbb-expanded) {
+    & > .sbb-expansion-indicator {
+      @include expansionIndicator(false);
+    }
   }
 }

--- a/projects/sbb-esta/angular-public/src/lib/accordion/expansion-panel/expansion-panel.component.spec.ts
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/expansion-panel/expansion-panel.component.spec.ts
@@ -303,16 +303,14 @@ describe('ExpansionPanelComponent', () => {
     const fixture = TestBed.createComponent(PanelWithContentComponent);
     fixture.detectChanges();
 
-    const header = fixture.debugElement.query(By.css('.sbb-expansion-panel-header')).nativeElement;
-
-    expect(header.querySelector('.sbb-expansion-indicator')).toBeTruthy(
+    expect(fixture.debugElement.query(By.css('.sbb-no-toggle'))).toBeFalsy(
       'Expected indicator to be shown.'
     );
 
     fixture.componentInstance.hideToggle = true;
     fixture.detectChanges();
 
-    expect(header.querySelector('.sbb-expansion-indicator')).toBeFalsy(
+    expect(fixture.debugElement.query(By.css('.sbb-no-toggle'))).toBeTruthy(
       'Expected indicator to be hidden.'
     );
   });
@@ -389,12 +387,12 @@ describe('ExpansionPanelComponent', () => {
     });
 
     it('should toggle the expansion indicator', () => {
-      expect(panel.querySelector('.sbb-expansion-indicator')).toBeTruthy();
+      expect(panel.querySelector('.sbb-no-toggle')).toBeFalsy();
 
       fixture.componentInstance.disabled = true;
       fixture.detectChanges();
 
-      expect(panel.querySelector('.sbb-expansion-indicator')).toBeFalsy();
+      expect(panel.querySelector('.sbb-no-toggle')).toBeTruthy();
     });
 
     it('should not be able to toggle the panel via a user action if disabled', () => {

--- a/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-header.scss
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-header.scss
@@ -107,17 +107,31 @@
   right: pxToEm($sbb-accordion-divider-left);
   width: pxToEm($sbb-accordion-toggle-size);
   height: pxToEm($sbb-accordion-toggle-size);
+
   background: url($sbb-accordion-toggle) no-repeat;
+  background-size: toPx($sbb-accordion-toggle-size) toPx($sbb-accordion-toggle-size);
 }
 
 @mixin expansionIndicatorBusiness() {
-  & > sbb-icon-plus::after {
-    @include exapansionToggleArrow();
+  & > sbb-icon-plus.sbb-icon-component {
+    & > svg {
+      display: none;
+    }
+
+    &::after {
+      @include exapansionToggleArrow();
+    }
   }
 
-  & > sbb-icon-minus::after {
-    @include exapansionToggleArrow();
-    transform-origin: toPx($sbb-accordion-toggle-size / 2) toPx($sbb-accordion-toggle-size / 4);
-    transform: rotate(180deg);
+  & > sbb-icon-minus.sbb-icon-component {
+    & > svg {
+      display: none;
+    }
+
+    &::after {
+      @include exapansionToggleArrow();
+      transform-origin: toPx($sbb-accordion-toggle-size / 2) toPx($sbb-accordion-toggle-size / 4);
+      transform: rotate(180deg);
+    }
   }
 }

--- a/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-header.scss
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-header.scss
@@ -75,27 +75,7 @@
   }
 }
 
-@mixin expansionIndicator() {
-  @include svgIconColor($sbb-accordion-toggle-icon-color);
-  position: absolute;
-  top: 50%;
-  right: pxToEm($sbb-accordion-toggle-size);
-  width: pxToEm($sbb-accordion-toggle-size);
-  height: pxToEm($sbb-accordion-toggle-size);
-  border: 1px solid $sbb-accordion-toggle-color;
-  border-radius: 50%;
-  transform: translateY(-50%);
-  text-align: center;
-
-  svg {
-    width: pxToEm($sbb-accordion-toggle-icon-size);
-    height: pxToEm($sbb-accordion-toggle-icon-size);
-    vertical-align: middle;
-    margin-top: pxToEm(2);
-  }
-}
-
-@mixin exapansionToggleArrow() {
+@mixin expansionToggleArrow($icon) {
   content: '';
   display: inline-block;
 
@@ -108,30 +88,27 @@
   width: pxToEm($sbb-accordion-toggle-size);
   height: pxToEm($sbb-accordion-toggle-size);
 
-  background: url($sbb-accordion-toggle) no-repeat;
-  background-size: toPx($sbb-accordion-toggle-size) toPx($sbb-accordion-toggle-size);
+  background: url($icon) no-repeat;
+  background-position: center;
+  background-size: toPx($sbb-accordion-toggle-icon-size) toPx($sbb-accordion-toggle-icon-size);
 }
 
-@mixin expansionIndicatorBusiness() {
-  & > sbb-icon-plus.sbb-icon-component {
-    & > svg {
-      display: none;
+@mixin expansionIndicator($expanded) {
+  &::after {
+    @if $expanded {
+      @include expansionToggleArrow($sbb-accordion-toggle-expanded);
+
+      @include businessOnly() {
+        transform-origin: toPx($sbb-accordion-toggle-icon-size / 2) toPx($sbb-accordion-toggle-icon-size / 4);
+        transform: rotate(180deg);
+      }
+    } @else {
+      @include expansionToggleArrow($sbb-accordion-toggle);
     }
 
-    &::after {
-      @include exapansionToggleArrow();
-    }
-  }
-
-  & > sbb-icon-minus.sbb-icon-component {
-    & > svg {
-      display: none;
-    }
-
-    &::after {
-      @include exapansionToggleArrow();
-      transform-origin: toPx($sbb-accordion-toggle-size / 2) toPx($sbb-accordion-toggle-size / 4);
-      transform: rotate(180deg);
+    @include publicOnly() {
+      border: 1px solid $sbb-accordion-toggle-color;
+      border-radius: 50%;
     }
   }
 }

--- a/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-header.scss
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-header.scss
@@ -77,16 +77,17 @@
 
 @mixin expansionToggleArrow($icon) {
   content: '';
-  display: inline-block;
 
   @include absoluteCenterY;
-
-  position: absolute;
-  top: 50%;
 
   right: pxToEm($sbb-accordion-divider-left);
   width: pxToEm($sbb-accordion-toggle-size);
   height: pxToEm($sbb-accordion-toggle-size);
+
+  @include publicOnly() {
+    border: 1px solid $sbb-accordion-toggle-color;
+    border-radius: 50%;
+  }
 
   background: url($icon) no-repeat;
   background-position: center;
@@ -94,7 +95,7 @@
 }
 
 @mixin expansionIndicator($expanded) {
-  &::after {
+  &::before {
     @if $expanded {
       @include expansionToggleArrow($sbb-accordion-toggle-expanded);
 
@@ -104,11 +105,6 @@
       }
     } @else {
       @include expansionToggleArrow($sbb-accordion-toggle);
-    }
-
-    @include publicOnly() {
-      border: 1px solid $sbb-accordion-toggle-color;
-      border-radius: 50%;
     }
   }
 }

--- a/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-header.scss
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-header.scss
@@ -8,12 +8,14 @@
   position: relative;
   background-color: $sbb-accordion-header-bgcolor;
 
-  @include mq($from: desktop4k) {
-    font-size: toEm(1 * $scalingFactor4k);
-  }
+  @include publicOnly() {
+    @include mq($from: desktop4k) {
+      font-size: toEm(1 * $scalingFactor4k);
+    }
 
-  @include mq($from: desktop5k) {
-    font-size: toEm(1 * $scalingFactor5k);
+    @include mq($from: desktop5k) {
+      font-size: toEm(1 * $scalingFactor5k);
+    }
   }
 
   &:focus,
@@ -31,17 +33,19 @@
       display: block;
       position: absolute;
       height: 0;
-      width: calc(100% - #{toPx($sbb-accordion-toggle-size * 2)});
+      width: calc(100% - #{toPx($sbb-accordion-divider-left * 2)});
       bottom: 0;
-      left: toPx($sbb-accordion-toggle-size);
+      left: toPx($sbb-accordion-divider-left);
       border-bottom: 1px solid $sbb-accordion-body-expanded-border-color;
 
-      @include mq($from: desktop4k) {
-        border-width: toPx(1 * $scalingFactor4k);
-      }
+      @include publicOnly() {
+        @include mq($from: desktop4k) {
+          border-width: toPx(1 * $scalingFactor4k);
+        }
 
-      @include mq($from: desktop5k) {
-        border-width: toPx(1 * $scalingFactor5k);
+        @include mq($from: desktop5k) {
+          border-width: toPx(1 * $scalingFactor5k);
+        }
       }
     }
   }
@@ -67,7 +71,7 @@
     overflow: hidden;
     font-size: pxToEm($sbb-accordion-header-font-size);
     font-family: $fontSbbLight;
-    line-height: 1.3;
+    line-height: $sbb-accordion-header-content-line-height;
   }
 }
 
@@ -88,5 +92,32 @@
     height: pxToEm($sbb-accordion-toggle-icon-size);
     vertical-align: middle;
     margin-top: pxToEm(2);
+  }
+}
+
+@mixin exapansionToggleArrow() {
+  content: '';
+  display: inline-block;
+
+  @include absoluteCenterY;
+
+  position: absolute;
+  top: 50%;
+
+  right: pxToEm($sbb-accordion-divider-left);
+  width: pxToEm($sbb-accordion-toggle-size);
+  height: pxToEm($sbb-accordion-toggle-size);
+  background: url($sbb-accordion-toggle) no-repeat;
+}
+
+@mixin expansionIndicatorBusiness() {
+  & > sbb-icon-plus::after {
+    @include exapansionToggleArrow();
+  }
+
+  & > sbb-icon-minus::after {
+    @include exapansionToggleArrow();
+    transform-origin: toPx($sbb-accordion-toggle-size / 2) toPx($sbb-accordion-toggle-size / 4);
+    transform: rotate(180deg);
   }
 }

--- a/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-panel.scss
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-panel.scss
@@ -7,24 +7,28 @@
   transition: margin 225ms $sbb-accordion-timing-function;
   border: 1px solid transparent;
 
-  @include mq($from: desktop4k) {
-    border-width: toPx(1 * $scalingFactor4k);
-  }
+  @include publicOnly() {
+    @include mq($from: desktop4k) {
+      border-width: toPx(1 * $scalingFactor4k);
+    }
 
-  @include mq($from: desktop5k) {
-    border-width: toPx(1 * $scalingFactor5k);
+    @include mq($from: desktop5k) {
+      border-width: toPx(1 * $scalingFactor5k);
+    }
   }
 
   &.sbb-expanded {
     border-color: $sbb-accordion-body-expanded-border-color;
     margin-bottom: toPx(2);
 
-    @include mq($from: desktop4k) {
-      margin-bottom: toPx(2 * $scalingFactor4k);
-    }
+    @include publicOnly() {
+      @include mq($from: desktop4k) {
+        margin-bottom: toPx(2 * $scalingFactor4k);
+      }
 
-    @include mq($from: desktop5k) {
-      margin-bottom: toPx(2 * $scalingFactor5k);
+      @include mq($from: desktop5k) {
+        margin-bottom: toPx(2 * $scalingFactor5k);
+      }
     }
   }
 }
@@ -44,11 +48,17 @@
     padding: $sbb-accordion-content-padding;
   }
 
-  @include mq($from: desktop4k) {
-    font-size: toEm(1 * $scalingFactor4k);
+  @include publicOnly() {
+    @include mq($from: desktop4k) {
+      font-size: toEm(1 * $scalingFactor4k);
+    }
+
+    @include mq($from: desktop5k) {
+      font-size: toEm(1 * $scalingFactor5k);
+    }
   }
 
-  @include mq($from: desktop5k) {
-    font-size: toEm(1 * $scalingFactor5k);
+  @include businessOnly() {
+    line-height: pxToEm(23);
   }
 }

--- a/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-variables.scss
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-variables.scss
@@ -16,6 +16,9 @@ $sbb-accordion-header-font-size: 21;
 $sbb-accordion-header-bgcolor: $sbbColorMilk;
 $sbb-accordion-body-expanded-border-color: $sbbColorCloud;
 
+$sbb-accordion-toggle: 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23000%22%20d%3D%22M11.5%2C20.9997%20L11.5%2C3.9997%20M20%2C12.5002%20L3%2C12.5002%22%2F%3E%3C%2Fsvg%3E%0A';
+$sbb-accordion-toggle-expanded: 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23000%22%20d%3D%22M20%2C12.5002%20L3%2C12.5002%22%2F%3E%3C%2Fsvg%3E%0A';
+
 @if $sbbBusiness {
   $sbb-accordion-content-padding: pxToEm(12) pxToEm(16) pxToEm(13) pxToEm(16);
   $sbb-accordion-header-padding: pxToEm(12) pxToEm(48) pxToEm(13) pxToEm(16);
@@ -23,6 +26,7 @@ $sbb-accordion-body-expanded-border-color: $sbbColorCloud;
   $sbb-accordion-toggle-size: 24;
   $sbb-accordion-divider-left: 16;
   $sbb-accordion-header-content-line-height: toEm(24 / $sbb-accordion-header-font-size);
-}
 
-$sbb-accordion-toggle: 'data:image/svg+xml,%3Csvg%20version%3D%221.1%22%20id%3D%22_x30__1_%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20x%3D%220px%22%20y%3D%220px%22%20viewBox%3D%220%200%2024%2024%22%20style%3D%22enable-background%3Anew%200%200%2024%2024%3Bfill%3A%20%2523666%3B%22%20xml%3Aspace%3D%22preserve%22%3E%3Cpath%20d%3D%22M7.7%2C10.7L8.4%2C10l3.6%2C3.6l3.6-3.6l0.7%2C0.7L12%2C15L7.7%2C10.7z%22%2F%3E%3C%2Fsvg%3E';
+  $sbb-accordion-toggle: 'data:image/svg+xml,%3Csvg%20version%3D%221.1%22%20id%3D%22_x30__1_%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20x%3D%220px%22%20y%3D%220px%22%20viewBox%3D%220%200%2024%2024%22%20style%3D%22enable-background%3Anew%200%200%2024%2024%3Bfill%3A%20%2523666%3B%22%20xml%3Aspace%3D%22preserve%22%3E%3Cpath%20d%3D%22M7.7%2C10.7L8.4%2C10l3.6%2C3.6l3.6-3.6l0.7%2C0.7L12%2C15L7.7%2C10.7z%22%2F%3E%3C%2Fsvg%3E';
+  $sbb-accordion-toggle-expanded: $sbb-accordion-toggle;
+}

--- a/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-variables.scss
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-variables.scss
@@ -25,4 +25,4 @@ $sbb-accordion-body-expanded-border-color: $sbbColorCloud;
   $sbb-accordion-header-content-line-height: toEm(24 / $sbb-accordion-header-font-size);
 }
 
-$sbb-accordion-toggle: 'data:image/svg+xml,<svg version="1.1" id="_x30__1_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;fill: %23666;" xml:space="preserve"><path d="M7.7,10.7L8.4,10l3.6,3.6l3.6-3.6l0.7,0.7L12,15L7.7,10.7z"/></svg>';
+$sbb-accordion-toggle: 'data:image/svg+xml,%3Csvg%20version%3D%221.1%22%20id%3D%22_x30__1_%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20x%3D%220px%22%20y%3D%220px%22%20viewBox%3D%220%200%2024%2024%22%20style%3D%22enable-background%3Anew%200%200%2024%2024%3Bfill%3A%20%2523666%3B%22%20xml%3Aspace%3D%22preserve%22%3E%3Cpath%20d%3D%22M7.7%2C10.7L8.4%2C10l3.6%2C3.6l3.6-3.6l0.7%2C0.7L12%2C15L7.7%2C10.7z%22%2F%3E%3C%2Fsvg%3E';

--- a/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-variables.scss
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-variables.scss
@@ -4,12 +4,25 @@ $sbb-accordion-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !default;
 $sbb-accordion-toggle-size: 32;
 $sbb-accordion-toggle-icon-size: 24;
 $sbb-accordion-toggle-icon-color: $sbbColorGrey;
+$sbb-accordion-divider-left: 32;
 $sbb-accordion-toggle-color: $sbbColorStorm;
 $sbb-accordion-header-padding: pxToEm(40) pxToEm(32 + ($sbb-accordion-toggle-size + 5)) pxToEm(40)
   pxToEm(32);
 $sbb-accordion-header-padding-no-toggle: pxToEm(40) pxToEm(32);
+$sbb-accordion-header-content-line-height: 1.3;
 $sbb-accordion-content-padding-mobile: pxToEm(36) pxToEm(32);
 $sbb-accordion-content-padding: pxToEm(48) pxToEm(32);
 $sbb-accordion-header-font-size: 21;
 $sbb-accordion-header-bgcolor: $sbbColorMilk;
 $sbb-accordion-body-expanded-border-color: $sbbColorCloud;
+
+@if $sbbBusiness {
+  $sbb-accordion-content-padding: pxToEm(12) pxToEm(16) pxToEm(13) pxToEm(16);
+  $sbb-accordion-header-padding: pxToEm(12) pxToEm(48) pxToEm(13) pxToEm(16);
+  $sbb-accordion-header-padding-no-toggle: $sbb-accordion-content-padding;
+  $sbb-accordion-toggle-size: 24;
+  $sbb-accordion-divider-left: 16;
+  $sbb-accordion-header-content-line-height: toEm(24 / $sbb-accordion-header-font-size);
+}
+
+$sbb-accordion-toggle: 'data:image/svg+xml,<svg version="1.1" id="_x30__1_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;fill: %23666;" xml:space="preserve"><path d="M7.7,10.7L8.4,10l3.6,3.6l3.6-3.6l0.7,0.7L12,15L7.7,10.7z"/></svg>';

--- a/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-variables.scss
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-variables.scss
@@ -16,8 +16,8 @@ $sbb-accordion-header-font-size: 21;
 $sbb-accordion-header-bgcolor: $sbbColorMilk;
 $sbb-accordion-body-expanded-border-color: $sbbColorCloud;
 
-$sbb-accordion-toggle: 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23000%22%20d%3D%22M11.5%2C20.9997%20L11.5%2C3.9997%20M20%2C12.5002%20L3%2C12.5002%22%2F%3E%3C%2Fsvg%3E%0A';
-$sbb-accordion-toggle-expanded: 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23000%22%20d%3D%22M20%2C12.5002%20L3%2C12.5002%22%2F%3E%3C%2Fsvg%3E%0A';
+$sbb-accordion-toggle: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWluWU1pZCI+PHBhdGggZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMDAwIiBkPSJNMTEuNSwyMC45OTk3IEwxMS41LDMuOTk5NyBNMjAsMTIuNTAwMiBMMywxMi41MDAyIi8+PC9zdmc+';
+$sbb-accordion-toggle-expanded: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiMwMDAiIGQ9Ik0yMCwxMi41MDAyIEwzLDEyLjUwMDIiLz48L3N2Zz4=';
 
 @if $sbbBusiness {
   $sbb-accordion-content-padding: pxToEm(12) pxToEm(16) pxToEm(13) pxToEm(16);
@@ -27,6 +27,6 @@ $sbb-accordion-toggle-expanded: 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%
   $sbb-accordion-divider-left: 16;
   $sbb-accordion-header-content-line-height: toEm(24 / $sbb-accordion-header-font-size);
 
-  $sbb-accordion-toggle: 'data:image/svg+xml,%3Csvg%20version%3D%221.1%22%20id%3D%22_x30__1_%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20x%3D%220px%22%20y%3D%220px%22%20viewBox%3D%220%200%2024%2024%22%20style%3D%22enable-background%3Anew%200%200%2024%2024%3Bfill%3A%20%2523666%3B%22%20xml%3Aspace%3D%22preserve%22%3E%3Cpath%20d%3D%22M7.7%2C10.7L8.4%2C10l3.6%2C3.6l3.6-3.6l0.7%2C0.7L12%2C15L7.7%2C10.7z%22%2F%3E%3C%2Fsvg%3E';
+  $sbb-accordion-toggle: 'data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJfeDMwX18xXyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiIHZpZXdCb3g9IjAgMCAyNCAyNCIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMjQgMjQ7ZmlsbDogJTIzNjY2OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+PHBhdGggZD0iTTcuNywxMC43TDguNCwxMGwzLjYsMy42bDMuNi0zLjZsMC43LDAuN0wxMiwxNUw3LjcsMTAuN3oiLz48L3N2Zz4=';
   $sbb-accordion-toggle-expanded: $sbb-accordion-toggle;
 }


### PR DESCRIPTION
Exposes the accordion component for business applications. Styling should be accoring to the [SBB Style Guide for Business Applications](https://digital.sbb.ch/en/webapps/components/accordion).

For the toggle I used a background-svg similar to the native select, for not needing to tamper with the html code of the components. Otherwise I would have to extend multiple components just to exchange the icon.

Closes #77

![business-accordion](https://user-images.githubusercontent.com/6132018/61117700-64393b00-a497-11e9-8525-835e355b334b.gif)