### PR TITLE
fix(select): show correct toggle in IE11

### DIFF
--- a/projects/sbb-esta/angular-public/src/styles/typography/_form.scss
+++ b/projects/sbb-esta/angular-public/src/styles/typography/_form.scss
@@ -64,7 +64,7 @@
 
 @mixin nativeSelectBase {
   $selectArrowWidthHeight: 24;
-  $selectNativeBackground: 'data:image/svg+xml,<svg version="1.1" id="_x30__1_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;fill: %23666;" xml:space="preserve"><path d="M7.7,10.7L8.4,10l3.6,3.6l3.6-3.6l0.7,0.7L12,15L7.7,10.7z"/></svg>';
+  $selectNativeBackground: 'data:image/svg+xml,%3Csvg%20version%3D%221.1%22%20id%3D%22_x30__1_%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20x%3D%220px%22%20y%3D%220px%22%20viewBox%3D%220%200%2024%2024%22%20style%3D%22enable-background%3Anew%200%200%2024%2024%3Bfill%3A%20%2523666%3B%22%20xml%3Aspace%3D%22preserve%22%3E%3Cpath%20d%3D%22M7.7%2C10.7L8.4%2C10l3.6%2C3.6l3.6-3.6l0.7%2C0.7L12%2C15L7.7%2C10.7z%22%2F%3E%3C%2Fsvg%3E';
   $selectArrowRight: 12;
   $selectTriggerPaddingRight: 44;
 
@@ -76,26 +76,30 @@
   @include inputfields;
   cursor: pointer;
   align-items: center;
-  width: 100%;
+  width: calc(100% - 0px); // IE11 does not support background images with width in percentages
   padding-right: toPx($selectTriggerPaddingRight);
 
   &:disabled {
     cursor: default;
   }
 
+  &::-ms-expand {
+    display: none;
+  }
+
   background: url($selectNativeBackground) no-repeat;
   background-position: center right toPx($selectArrowRight);
-  background-size: toPx($selectArrowWidthHeight);
+  background-size: toPx($selectArrowWidthHeight) toPx($selectArrowWidthHeight);
 
   @include publicOnly() {
     @include mq($from: desktop4k) {
-      background-size: toPx($selectArrowWidthHeight * $scalingFactor4k);
       background-position: center right toPx($selectArrowRight * $scalingFactor4k);
+      background-size: toPx($selectArrowWidthHeight * $scalingFactor4k) toPx($selectArrowWidthHeight * $scalingFactor4k);
     }
 
     @include mq($from: desktop5k) {
-      background-size: toPx($selectArrowWidthHeight * $scalingFactor5k);
       background-position: center right toPx($selectArrowRight * $scalingFactor5k);
+      background-size: toPx($selectArrowWidthHeight * $scalingFactor5k) toPx($selectArrowWidthHeight * $scalingFactor5k);
     }
   }
 }


### PR DESCRIPTION
This disables the native dropdown toggle for native select in IE11. There is also a workaround in this commit:

```scss
width: calc(100% - 0px); // IE11 does not support background images with width in percentages
```

With `width: 100%` the toggle on IE11 is not visible.

Closes #102 

![select-native](https://user-images.githubusercontent.com/6132018/61135462-f5250c00-a4c1-11e9-9717-fb12435d929d.gif)