### PR TITLE
fix(business/checkbox): add sbb-checkbox class to public and business

### DIFF
--- a/projects/sbb-esta/angular-business/src/lib/checkbox/checkbox/checkbox.component.spec.ts
+++ b/projects/sbb-esta/angular-business/src/lib/checkbox/checkbox/checkbox.component.spec.ts
@@ -81,9 +81,7 @@ describe('CheckboxComponent using mock component', () => {
   });
 
   it('should have sbb-checkbox class', () => {
-    const checkboxComp = modelComponentFixture.debugElement.query(
-      By.css('.sbb-checkbox')
-    );
+    const checkboxComp = modelComponentFixture.debugElement.query(By.css('.sbb-checkbox'));
     expect(checkboxComp).toBeTruthy();
   });
 

--- a/projects/sbb-esta/angular-business/src/lib/checkbox/checkbox/checkbox.component.spec.ts
+++ b/projects/sbb-esta/angular-business/src/lib/checkbox/checkbox/checkbox.component.spec.ts
@@ -80,6 +80,13 @@ describe('CheckboxComponent using mock component', () => {
     expect(modelComponent).toBeTruthy();
   });
 
+  it('should have sbb-checkbox class', () => {
+    const checkboxComp = modelComponentFixture.debugElement.query(
+      By.css('.sbb-checkbox')
+    );
+    expect(checkboxComp).toBeTruthy();
+  });
+
   it('should not have class for indeterminate', () => {
     const checkboxComponentIndeterminate = modelComponentFixture.debugElement.query(
       By.css('.sbb-checkbox-indeterminate')

--- a/projects/sbb-esta/angular-public/src/lib/checkbox/checkbox/checkbox-base.ts
+++ b/projects/sbb-esta/angular-public/src/lib/checkbox/checkbox/checkbox-base.ts
@@ -83,6 +83,8 @@ export class CheckboxBase implements ControlValueAccessor {
   }
   private _disabled = false;
   /** @docs-private */
+  @HostBinding('class.sbb-checkbox') checkboxClass = true;
+  /** @docs-private */
   @HostBinding('attr.tabindex') _tabIndex = null;
   /** Event emitted when the checkbox's `checked` value changes. */
   @Output() readonly change = new EventEmitter<SbbCheckboxChange<this>>();

--- a/projects/sbb-esta/angular-public/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/projects/sbb-esta/angular-public/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -28,9 +28,6 @@ import { CheckboxBase } from './checkbox-base';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CheckboxComponent extends CheckboxBase {
-  /** @docs-private */
-  @HostBinding('class.sbb-checkbox') checkboxClass = true;
-
   constructor(
     changeDetectorRef: ChangeDetectorRef,
     focusMonitor: FocusMonitor,


### PR DESCRIPTION
Moves the binding of the class sbb-checkbox to the base checkbox component. Otherwise the correct styling is not applied to business components.

If possible, can you please create a patch-release of the business package after merging.