### PR TITLE
fix(toggle): use for-loop in place of forEach on NodeList (#125)

### DIFF
--- a/projects/sbb-esta/angular-public/src/lib/toggle/toggle-option/toggle-option.component.ts
+++ b/projects/sbb-esta/angular-public/src/lib/toggle/toggle-option/toggle-option.component.ts
@@ -200,11 +200,13 @@ export class ToggleOptionComponent extends RadioButtonComponent
   filteredContentNodes: ChildNode[] = [];
 
   ngAfterViewInit() {
-    this.contentContainer.nativeElement.childNodes.forEach(node => {
+    const nodeList = this.contentContainer.nativeElement.childNodes;
+    for (let k = 0; k < nodeList.length; k++) {
+      const node = nodeList.item(k);
       if (node.nodeType !== this._document.COMMENT_NODE) {
         this.filteredContentNodes.push(node);
       }
-    });
+    }
 
     if (!this.filteredContentNodes.length) {
       this.toggleOptionHasContent = false;


### PR DESCRIPTION
IE11 doesn't support .forEach on NodeLists, which was causing the issue.
An alternative could be adding a generic polyfill for the issue.