### PR TITLE
fix(business/accordion): remove media query breakpoints

### DIFF
--- a/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-panel.scss
+++ b/projects/sbb-esta/angular-public/src/lib/accordion/styles/_accordion-panel.scss
@@ -42,13 +42,13 @@
 }
 
 @mixin expansionPanelBody() {
-  padding: $sbb-accordion-content-padding-mobile;
-
-  @include mq($from: tabletPortrait) {
-    padding: $sbb-accordion-content-padding;
-  }
-
   @include publicOnly() {
+    padding: $sbb-accordion-content-padding-mobile;
+
+    @include mq($from: tabletPortrait) {
+      padding: $sbb-accordion-content-padding;
+    }
+
     @include mq($from: desktop4k) {
       font-size: toEm(1 * $scalingFactor4k);
     }
@@ -59,6 +59,7 @@
   }
 
   @include businessOnly() {
+    padding: $sbb-accordion-content-padding;
     line-height: pxToEm(23);
   }
 }


### PR DESCRIPTION
This fixes an unwanted jump in padding when the screen gets small for the business theme.