### PR TITLE
fix(business/button): add icon content child to component and template

### DIFF
--- a/projects/sbb-esta/angular-business/button/src/button/button.component.html
+++ b/projects/sbb-esta/angular-business/button/src/button/button.component.html
@@ -1,1 +1,7 @@
+<span class="sbb-svgsprite-icon">
+  <ng-container *ngTemplateOutlet="icon"></ng-container>
+</span>
 <ng-content></ng-content>
+<span class="sbb-svgsprite-icon">
+  <ng-container *ngTemplateOutlet="icon"></ng-container>
+</span>

--- a/projects/sbb-esta/angular-business/button/src/button/button.component.ts
+++ b/projects/sbb-esta/angular-business/button/src/button/button.component.ts
@@ -1,11 +1,14 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ContentChild,
   HostBinding,
   Input,
+  TemplateRef,
   ViewEncapsulation
 } from '@angular/core';
 import { BaseButton } from '@sbb-esta/angular-core/base';
+import { IconDirective } from '@sbb-esta/angular-core/icon-directive';
 
 @Component({
   // tslint:disable-next-line:component-selector
@@ -20,6 +23,28 @@ export class ButtonComponent extends BaseButton {
    * Button modes available for different purposes.
    */
   @Input() mode: 'primary' | 'secondary' | 'ghost' | 'alternative' | 'icon' = 'primary';
+
+  /**
+   * Template that will contain icons.
+   * Use the *sbbIcon structural directive to provide the desired icon.
+   */
+  @Input()
+  get icon(): TemplateRef<any> {
+    return this._contentIcon || this._icon;
+  }
+  set icon(icon: TemplateRef<any>) {
+    this._icon = icon;
+  }
+  private _icon: TemplateRef<any>;
+
+  /** @docs-private */
+  @HostBinding('class.sbb-button-has-icon') get buttonHasIconClass() {
+    return !!this.icon;
+  }
+
+  /** @docs-private */
+  @ContentChild(IconDirective, { read: TemplateRef, static: false })
+  _contentIcon: TemplateRef<any>;
 
   /** @docs-private */
   @HostBinding('class.sbb-button-alternative')


### PR DESCRIPTION
I added to necessary instructions directly to the business button. This hopefully displays the icons again. If I have time, I will someday refactor the stylings, so there is another template, but for the moment, I would just like to get it to work. So a bugfix release asap would be appreciated, otherwise I would have to rollback to an older version.

In my tests the directive 
```html
<button sbbButton mode="icon">
  <sbb-icon-arrow-right *sbbIcon></sbb-icon-arrow-right>
</button>
```
still did not work, but I hope this is due to my test setup. However,
```html
<ng-template #icon>
  <sbb-icon-arrow-right></sbb-icon-arrow-right>
</ng-template>
<button sbbButton mode="icon" [icon]="icon">
```
works fine.